### PR TITLE
Grace Gawker v0.1.1.0 Update

### DIFF
--- a/testing/live/GraceGawker/manifest.toml
+++ b/testing/live/GraceGawker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/mashirochan/FFXIV-GraceGawker.git"
-commit = "09630ba102843957a27ea81ed3e535b932fb1d80"
+commit = "385fd660818f95992bf8890b4cfc4a553986c44a"
 owners = ["mashirochan"]
 project_path = "GraceGawker"
-changelog = "Initial plugin test release!"
+changelog = "Update to Dalamud API v11 and add percent coloring option"


### PR DESCRIPTION
This update upgrades the plugin to Dalamud API v11 and adds a percent coloring option for when the currently equipped job doesn't receive the bonus grace exp because it's too high of a level

Hopefully this is the right way to do this... Also, I'm curious how/if I can go about getting my plugin moved over from testing over to the stable section so everyone can see it!